### PR TITLE
Fix heatmap figure sizing in RMarkdown reports

### DIFF
--- a/inst/rmarkdown/de/DifferentialExpression.Rmd
+++ b/inst/rmarkdown/de/DifferentialExpression.Rmd
@@ -71,9 +71,17 @@ datatable(resultTable, options = list(pageLength = 10, scollX = 400))
 
 ## Heatmap
 
-The following heatmap will be divided by the conditions and the regulation. A gene will be determined as up-regulated in condition **`r cond1`** if its log2FC value was greater than 0.25 and FDR is less than 0.05, and down-regulated in condition **`r cond1`** if the log2FC value is less than -0.25. The gene regulation and condition setting will be annotated by default. In addition, if the condition setting was achieved by using a categorical annotation in the object, the annotation used will also be labeled to the column level of the heatmap. 
+The following heatmap will be divided by the conditions and the regulation. A gene will be determined as up-regulated in condition **`r cond1`** if its log2FC value was greater than 0.25 and FDR is less than 0.05, and down-regulated in condition **`r cond1`** if the log2FC value is less than -0.25. The gene regulation and condition setting will be annotated by default. In addition, if the condition setting was achieved by using a categorical annotation in the object, the annotation used will also be labeled to the column level of the heatmap.
 
-```{r "DE-Vis-heatmap", results="asis", fig.align="center", warning=FALSE, message=FALSE, fig.width=9, fig.height=10}
+```{r "DE-Vis-heatmap-calc", include=FALSE}
+# Calculate dynamic height based on number of DEGs
+degTable <- getDEGTopTable(sce, useResult = study, log2fcThreshold = 0.25, fdrThreshold = 0.05)
+numDEGs <- nrow(degTable)
+# Set minimum height of 8, with 0.15 inches per DEG, max 30
+degHeatmapHeight <- max(8, min(numDEGs * 0.15, 30))
+```
+
+```{r "DE-Vis-heatmap", results="asis", fig.align="center", warning=FALSE, message=FALSE, fig.width=12, fig.height=degHeatmapHeight}
 plotDEGHeatmap(sce, study, rowLabel = featureDisplay)
 ```
 

--- a/inst/rmarkdown/de/FindMarker.Rmd
+++ b/inst/rmarkdown/de/FindMarker.Rmd
@@ -107,14 +107,22 @@ for (i in uniqClusters) {
 
 ## Heatmap
 
-In the marker heatmap, each column stands for a cell in the given SingleCellExperiment object. The cell level color bar annotates the cluster assignment. Each row is a marker gene, and the gene level color bar assigns the cluster correspondence. The cell cluster is ordered by the cluster population size.  
+In the marker heatmap, each column stands for a cell in the given SingleCellExperiment object. The cell level color bar annotates the cluster assignment. Each row is a marker gene, and the gene level color bar assigns the cluster correspondence. The cell cluster is ordered by the cluster population size.
 
-It happens sometimes that a gene is identified as the marker for more than one cluster. In this scenario, we finally assign it to the cluster where it has a higher "logFC" value when plotting.  
+It happens sometimes that a gene is identified as the marker for more than one cluster. In this scenario, we finally assign it to the cluster where it has a higher "logFC" value when plotting.
 
-```{r FM-heatmap, message=FALSE, warning=FALSE, out.width = '100%'}
-plotFindMarkerHeatmap(sce, 
-                  log2fcThreshold = 0.5, 
-                  minClustExprPerc = 0.7, 
-                  maxCtrlExprPerc = 0.4, 
+```{r FM-heatmap-calc, include=FALSE}
+# Calculate dynamic height based on number of markers
+# Estimate: up to 10 markers per cluster
+estimatedMarkers <- min(nCluster * 10, nrow(fmTable))
+# Set minimum height of 8, with 0.2 inches per marker gene
+heatmapHeight <- max(8, min(estimatedMarkers * 0.2, 30))
+```
+
+```{r FM-heatmap, message=FALSE, warning=FALSE, fig.width=12, fig.height=heatmapHeight}
+plotFindMarkerHeatmap(sce,
+                  log2fcThreshold = 0.5,
+                  minClustExprPerc = 0.7,
+                  maxCtrlExprPerc = 0.4,
                   minMeanExpr = 1)
 ```


### PR DESCRIPTION
- Added dynamic height calculation for FindMarker heatmap based on number of marker genes (estimated from number of clusters)
- Added dynamic height calculation for DifferentialExpression heatmap based on actual number of DEGs passing filters
- Increased default width from 9 to 12 inches for better visibility
- Heights now scale with content (0.15-0.2 inches per gene) with min of 8 and max of 30 inches to prevent squished or oversized figures

This fixes the issue where heatmaps could be visually squished when there are many markers or DEGs in the analysis.